### PR TITLE
fix meshing problem:

### DIFF
--- a/src/lib/isosurface_inflator/CGALClippedVolumeMesher.cc
+++ b/src/lib/isosurface_inflator/CGALClippedVolumeMesher.cc
@@ -156,7 +156,8 @@ mesh(const SignedDistanceRegion<3> &sdf,
     // Mesh generation
     // std::cout << "Making mesh..." << std::endl;
     BENCHMARK_START_TIMER("make_mesh_3");
-    C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria);
+    C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria, CGAL::parameters::features(domain),
+		    CGAL::parameters::odt(), CGAL::parameters::perturb(0, 20), CGAL::parameters::exude(0, 20));
     // CGAL sometimes returns an empty mesh for some patterns due to
     // insufficient initialization:
     // https://github.com/CGAL/cgal/issues/2416

--- a/src/lib/isosurface_inflator/ConvexHullTriangulation.cc
+++ b/src/lib/isosurface_inflator/ConvexHullTriangulation.cc
@@ -44,7 +44,7 @@ void convexHullFromTriangulation(const PointCollection &points,
     for (size_t i = 0; 3 * i < indexBuffer.size(); ++i) {
         hullElements[i].resize(3);
         for (size_t lv = 0; lv < 3; ++lv) {
-            hullElements[i][lv] = newVertexId[indexBuffer[i * lv + lv]];
+            hullElements[i][lv] = newVertexId[indexBuffer[i * 3 + lv]];
         }
     }
 }

--- a/src/lib/isosurface_inflator/PostProcess.cc
+++ b/src/lib/isosurface_inflator/PostProcess.cc
@@ -125,7 +125,8 @@ void postProcess(vector<MeshIO::IOVertex>  &vertices,
                     << "WARNING: smartSnap3D failed--probably nonsmooth geometry at cell interface. Resorting to dumbSnap3D."
                     << std::endl;
             std::cerr << "(" << e.what() << ")" << std::endl;
-            dumbSnap3D(vertices, meshCell, opts.facetDistance);
+            // dumbSnap3D(vertices, meshCell, opts.facetDistance);
+            dumbSnap3D(vertices, meshCell, 2 * opts.domainErrorBound);
         }
         BBox<Point3D> snappedBB(vertices);
         if (N == 2) {


### PR DESCRIPTION
1. incorrect vertex indexing in convex hull computation;
2. remove potential sliver in CGAL generated mesh by using ODT and minumus angle bound.
3. improve the distance tolerence in dumbSnap3D.